### PR TITLE
Cherry-pick -Wstringop-truncation warnings fix

### DIFF
--- a/arch/Sparc/SparcInstPrinter.c
+++ b/arch/Sparc/SparcInstPrinter.c
@@ -358,7 +358,7 @@ void Sparc_printInst(MCInst *MI, SStream *O, void *Info)
 	mnem = printAliasInstr(MI, O, Info);
 	if (mnem) {
 		// fixup instruction id due to the change in alias instruction
-		strncpy(instr, mnem, sizeof(instr));
+		strncpy(instr, mnem, sizeof(instr) - 1);
 		instr[sizeof(instr) - 1] = '\0';
 		// does this contains hint with a coma?
 		p = strchr(instr, ',');

--- a/cs.c
+++ b/cs.c
@@ -576,7 +576,7 @@ static void fill_insn(struct cs_struct *handle, cs_insn *insn, char *buffer, MCI
 		while(tmp) {
 			if (tmp->insn.id == insn->id) {
 				// found this instruction, so copy its mnemonic
-				(void)strncpy(insn->mnemonic, tmp->insn.mnemonic, sizeof(insn->mnemonic) - 1);
+				(void)strncpy(insn->mnemonic, tmp->insn.mnemonic, sizeof(insn->mnemonic));
 				insn->mnemonic[sizeof(insn->mnemonic) - 1] = '\0';
 				break;
 			}


### PR DESCRIPTION
As per https://github.com/rizinorg/capstone/pull/1#issuecomment-791436038, this pr cherry-picks the [upstream fix](https://github.com/aquynh/capstone/commit/8635f65661824f7e677e7c0d1b1f620d869ed847) for the `-Wstringop-truncation` warnings.