### PR TITLE
Update rizinorg/capstone:v4 to capstone-engine/capstone:v4 HEAD

### DIFF
--- a/arch/M680X/M680XDisassembler.c
+++ b/arch/M680X/M680XDisassembler.c
@@ -2121,11 +2121,6 @@ static const cpu_tables g_cpu_tables[] = {
 	},
 };
 
-static const char *s_cpu_type[] = {
-	"INVALID", "6301", "6309", "6800", "6801", "6805", "6808",
-	"6809", "6811", "CPU12", "HCS08",
-};
-
 static bool m680x_setup_internals(m680x_info *info, e_cpu_type cpu_type,
 	uint16_t address,
 	const uint8_t *code, uint16_t code_len)
@@ -2251,12 +2246,6 @@ cs_err M680X_disassembler_init(cs_struct *ud)
 
 	if (M680X_INS_ENDING != ARR_SIZE(g_insn_props)) {
 		CS_ASSERT(M680X_INS_ENDING == ARR_SIZE(g_insn_props));
-
-		return CS_ERR_MODE;
-	}
-
-	if (M680X_CPU_TYPE_ENDING != ARR_SIZE(s_cpu_type)) {
-		CS_ASSERT(M680X_CPU_TYPE_ENDING == ARR_SIZE(s_cpu_type));
 
 		return CS_ERR_MODE;
 	}


### PR DESCRIPTION
This pr updates rizinorg/capstone:v4 to 0efa3cc530ea188c0e03c945ab884ee19dd16342 (capstone-engine/capstone:v4 HEAD) i.e. the fix for the following warning:

![s_cpu_type](https://user-images.githubusercontent.com/12002672/144400756-45e8bc70-a91c-4901-8050-2ff8ff76f7e4.PNG)
(https://github.com/rizinorg/rizin/runs/4351274434?check_suite_focus=true#step:12:697)

